### PR TITLE
freebsd.{,boot-}install: build with BOOTSTRAPPING defined

### DIFF
--- a/pkgs/os-specific/bsd/freebsd/boot-install.nix
+++ b/pkgs/os-specific/bsd/freebsd/boot-install.nix
@@ -18,7 +18,7 @@ in mkDerivation {
   skipIncludesPhase = true;
   buildInputs = compatIfNeeded ++ [libmd];
   buildPhase = ''
-    make -C $BSDSRCDIR/usr.bin/xinstall STRIP=-s MK_WERROR=no TESTDIR=${builtins.placeholder "test"}
+    make -C $BSDSRCDIR/usr.bin/xinstall STRIP=-s MK_WERROR=no TESTDIR=${builtins.placeholder "test"} BOOTSTRAPPING=1
   '';
   installPhase = ''
     mkdir -p $out/bin

--- a/pkgs/os-specific/bsd/freebsd/by-name/install.nix
+++ b/pkgs/os-specific/bsd/freebsd/by-name/install.nix
@@ -19,7 +19,10 @@ let binstall = buildPackages.writeShellScript "binstall" (install-wrapper + ''
     "STRIP=-s" # flag to install, not command
     "MK_WERROR=no"
     "TESTSDIR=${builtins.placeholder "test"}"
-  ] ++ lib.optional (stdenv.hostPlatform == stdenv.buildPlatform) "INSTALL=boot-install";
+  ] ++ lib.optionals (stdenv.hostPlatform == stdenv.buildPlatform) [
+    "BOOTSTRAPPING=1"
+    "INSTALL=boot-install"
+  ];
   postInstall = ''
     install -D -m 0550 ${binstall} $out/bin/binstall
     substituteInPlace $out/bin/binstall --subst-var out

--- a/pkgs/os-specific/bsd/freebsd/by-name/libpfctl.nix
+++ b/pkgs/os-specific/bsd/freebsd/by-name/libpfctl.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, ...}:
+mkDerivation {
+  path = "lib/libpfctl";
+  extraPaths = [ "sys" ];
+  preBuild = ''
+    export NIX_CFLAGS_COMPILE="$NIX_CFLAGS_COMPILE -Wno-typedef-redefinition -I../../sys"
+  '';
+  dontFixup = true;
+  # preInstall = ''
+  #   set -x
+  #   pwd
+  #   cd lib/pfctl
+  # '';
+  installPhase = ''
+    mkdir -p $out/lib
+    ls -l *.so *.a
+    cp libpfctl{,_pie}.a $out/lib
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/by-name/pfctl.nix
+++ b/pkgs/os-specific/bsd/freebsd/by-name/pfctl.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, buildFreebsd, libnv, libpfctl, yacc, stdenv, ...}:
+mkDerivation {
+  path = "sbin/pfctl";
+  extraPaths = [
+    "sys"
+    "lib/libpfctl"
+  ];
+  nativeBuildInputs = [
+    yacc
+    buildFreebsd.bmakeMinimal
+    (if stdenv.hostPlatform == stdenv.buildPlatform
+     then buildFreebsd.boot-install
+     else buildFreebsd.install)
+  ];
+  buildInputs = [ libnv libpfctl ];
+  MK_TESTS = "no";
+
+  preBuild = ''
+    cd sbin/pfctl
+    NIX_CFLAGS_COMPILE+=' -I../../lib/libpfctl -Wno-error=typedef-redefinition';
+  '';
+  installFlags = [ "DESTDIR=${placeholder "out"}" ];
+  postInstall = ''
+    mkdir $out/sbin
+    mv $out/pfctl $out/sbin/
+  '';
+}

--- a/pkgs/os-specific/bsd/freebsd/by-name/top.nix
+++ b/pkgs/os-specific/bsd/freebsd/by-name/top.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, lib, libjail, libncurses-tinfo, libsbuf }:
+mkDerivation {
+  path = "usr.bin/top";
+  buildInputs = [ libjail libncurses-tinfo libsbuf ];
+  preBuild = ''
+    NIX_CFLAGS_COMPILE+=' -Wno-error=typedef-redefinition';
+  '';
+
+  meta.platforms = lib.platforms.freebsd;
+}


### PR DESCRIPTION
This fixes the builds for me on NixOS/Linux, solving:
```
libnetbsd> --- _INCSINS ---
libnetbsd> xinstall: /nix/store/gghvrrvhqjq3f1qw4aqjfp36wiiv3hsg-libnetbsd-14.0/include/glob.h: Invalid cross-device link
libnetbsd> --- _NETINETINCSINS ---
libnetbsd> xinstall: /nix/store/gghvrrvhqjq3f1qw4aqjfp36wiiv3hsg-libnetbsd-14.0/include/netinet/in.h: Invalid cross-device link
libnetbsd> --- _SYSINCSINS ---
libnetbsd> xinstall: /nix/store/gghvrrvhqjq3f1qw4aqjfp36wiiv3hsg-libnetbsd-14.0/include/sys/cdefs.h: Invalid cross-device link
libnetbsd> --- _INCSINS ---
libnetbsd> *** [_INCSINS] Error code 71
libnetbsd> make: stopped in /build/libnetbsd-filtered-src/lib/libnetbsd
```
caused by:
```
copy_file_range(3, NULL, 4, NULL, 9223372036854775807, 0) = -1 EXDEV (Invalid cross-device link)
```